### PR TITLE
relative imports

### DIFF
--- a/packages/contracts/src/modules/vrf/BlockHashStore.sol
+++ b/packages/contracts/src/modules/vrf/BlockHashStore.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 
-import {RLPReader} from "src/modules/vrf/libraries/RLPReader.sol";
+import {RLPReader} from "./libraries/RLPReader.sol";
 
 contract BlockHashStore {
     mapping(uint256 => bytes32) public blockHashes;

--- a/packages/contracts/src/modules/vrf/VRFCoordinator.sol
+++ b/packages/contracts/src/modules/vrf/VRFCoordinator.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.8.0;
 
 import {System} from "@latticexyz/world/src/System.sol";
 
-import {VRF} from "src/modules/vrf/VRF.sol";
-import {IVRFCoordinator} from "src/modules/vrf/interfaces/IVRFCoordinator.sol";
-import {BlockHashStore} from "src/modules/vrf/BlockHashStore.sol";
+import {VRF} from "./VRF.sol";
+import {IVRFCoordinator} from "./interfaces/IVRFCoordinator.sol";
+import {BlockHashStore} from "./BlockHashStore.sol";
 
 /// @title VRFCoordinator
 /// @notice This contract handles requests and fulfillments of random words from a VRF.

--- a/packages/contracts/src/modules/vrf/VRFCoordinatorModule.sol
+++ b/packages/contracts/src/modules/vrf/VRFCoordinatorModule.sol
@@ -5,9 +5,9 @@ import {IBaseWorld} from "@latticexyz/world/src/interfaces/IBaseWorld.sol";
 import {IModule} from "@latticexyz/world/src/interfaces/IModule.sol";
 import {WorldContext} from "@latticexyz/world/src/WorldContext.sol";
 
-import {VRFCoordinator} from "src/modules/vrf/VRFCoordinator.sol";
-import {VRFCoordinatorSystem} from "src/modules/vrf/VRFCoordinatorSystem.sol";
-import {NAMESPACE, MODULE_NAME, SYSTEM_NAME, TABLE_NAME} from "src/modules/vrf/constants.sol";
+import {VRFCoordinator} from "./VRFCoordinator.sol";
+import {VRFCoordinatorSystem} from "./VRFCoordinatorSystem.sol";
+import {NAMESPACE, MODULE_NAME, SYSTEM_NAME, TABLE_NAME} from "./constants.sol";
 
 contract VRFCoordinatorModule is IModule, WorldContext {
     VRFCoordinatorSystem public immutable vrfCoordinatorSystem = new VRFCoordinatorSystem();

--- a/packages/contracts/src/modules/vrf/VRFCoordinatorSystem.sol
+++ b/packages/contracts/src/modules/vrf/VRFCoordinatorSystem.sol
@@ -3,9 +3,9 @@ pragma solidity >=0.8.0;
 
 import {System} from "@latticexyz/world/src/System.sol";
 
-import {VRF} from "src/modules/vrf/VRF.sol";
-import {VRFCoordinator} from "src/modules/vrf/VRFCoordinator.sol";
-import {VRFCoordinatorAddress} from "src/modules/vrf/tables/VRFCoordinatorAddress.sol";
+import {VRF} from "./VRF.sol";
+import {VRFCoordinator} from "./VRFCoordinator.sol";
+import {VRFCoordinatorAddress} from "./tables/VRFCoordinatorAddress.sol";
 
 /// @title VRFCoordinatorSystem
 /// @notice This contract handles requests and fulfillments of random words from a VRF.

--- a/packages/example-contracts/foundry.toml
+++ b/packages/example-contracts/foundry.toml
@@ -8,7 +8,7 @@ verbosity = 1
 src = "src"
 test = "test"
 out = "out"
-allow_paths = ["../../node_modules", "../../../../packages"]
+allow_paths = ["../../node_modules", "../../packages"]
 extra_output_files = [
   "abi",
   "evm.bytecode"

--- a/packages/example-contracts/src/VRFCoordinatorModule.sol
+++ b/packages/example-contracts/src/VRFCoordinatorModule.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {VRFCoordinatorModule} from "@succinctlabs/mudvrf/modules/vrf/VRFCoordinatorModule.sol";


### PR DESCRIPTION
context from discord
> I think the solution might be the other way around - to use relative paths in ur contracts, will try to whip up an example and make a PR to ur repo
> it seems the problem there covers not just MUD but also forge stuff, and comes from the compiler considering the same file to not be the same if it comes from relative and absolute resolutions. And since usually (in forge and MUD) it's relative, you should also go that route

The second commit just adds an imported `VRFCoordinatorModule`, so it is visible to `mud test`, `mud deploy` etc within `example-contracts`.
Right now this is the caveat with external modules - you need to reimport their `*Module.sol`. Ideally MUD would handle it, but not sure how yet