### PR TITLE
refactor package names and remappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@succinctlabs/mudvrf",
+  "name": "mudvrf",
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,7 +23,7 @@
     "@latticexyz/utils": "2.0.0-alpha.1.196",
     "@latticexyz/world": "2.0.0-alpha.1.196",
     "@wagmi/chains": "^0.2.22",
-    "@succinctlabs/mudvrf-contracts": "workspace:*",
+    "@succinctlabs/mudvrf": "workspace:*",
     "ethers": "^5.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@succinctlabs/mudvrf-contracts",
+  "name": "@succinctlabs/mudvrf",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/packages/example-contracts/package.json
+++ b/packages/example-contracts/package.json
@@ -30,7 +30,7 @@
     "@latticexyz/world": "2.0.0-alpha.1.196",
     "@latticexyz/config": "2.0.0-alpha.1.196",
     "ethers": "^5.7.2",
-    "@succinctlabs/mudvrf-contracts": "workspace:*"
+    "@succinctlabs/mudvrf": "workspace:*"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^10.2.0",

--- a/packages/example-contracts/remappings.txt
+++ b/packages/example-contracts/remappings.txt
@@ -1,4 +1,4 @@
 ds-test/=./node_modules/ds-test/src/
 forge-std/=./node_modules/forge-std/src/
 @latticexyz/=./node_modules/@latticexyz/
-@succinctlabs/mudvrf/=./node_modules/@succinctlabs/mudvrf-contracts/src/
+@succinctlabs/=./node_modules/@succinctlabs/

--- a/packages/example-contracts/script/PostDeploy.s.sol
+++ b/packages/example-contracts/script/PostDeploy.s.sol
@@ -4,9 +4,9 @@ pragma solidity >=0.8.0;
 import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 // import {IWorld} from "../src/world/IWorld.sol";
-import {BlockHashStore} from "@succinctlabs/mudvrf/modules/vrf/BlockHashStore.sol";
-import {VRFCoordinator} from "@succinctlabs/mudvrf/modules/vrf/VRFCoordinator.sol";
-import {MockVRFCoordinator} from "@succinctlabs/mudvrf/modules/vrf/mocks/MockVRFCoordinator.sol";
+import {BlockHashStore} from "@succinctlabs/mudvrf/src/modules/vrf/BlockHashStore.sol";
+import {VRFCoordinator} from "@succinctlabs/mudvrf/src/modules/vrf/VRFCoordinator.sol";
+import {MockVRFCoordinator} from "@succinctlabs/mudvrf/src/modules/vrf/mocks/MockVRFCoordinator.sol";
 
 contract PostDeploy is Script {
     uint256 constant ANVIL_CHAIN_ID = 31337; 

--- a/packages/example-contracts/src/systems/BlackJackSystem.sol
+++ b/packages/example-contracts/src/systems/BlackJackSystem.sol
@@ -5,7 +5,7 @@ import {System} from "@latticexyz/world/src/System.sol";
 
 import {RequestIdToBlackJackUser, BlackJack} from "../Tables.sol";
 import {IBlackJackSystem} from "../world/IBlackJackSystem.sol";
-import {IVRFCoordinatorSystem} from "@succinctlabs/mudvrf/world/IVRFCoordinatorSystem.sol";
+import {IVRFCoordinatorSystem} from "@succinctlabs/mudvrf/src/world/IVRFCoordinatorSystem.sol";
 
 contract BlackJackSystem is System {
     bytes32 public constant ORACLE_ID = bytes32(hex"c1ffd3cfee2d9e5cd67643f8f39fd6e51aad88f6f4ce6ab8827279cfffb92266");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
       '@latticexyz/world':
         specifier: 2.0.0-alpha.1.196
         version: 2.0.0-alpha.1.196(typescript@5.0.4)
-      '@succinctlabs/mudvrf-contracts':
+      '@succinctlabs/mudvrf':
         specifier: workspace:*
         version: link:../contracts
       '@wagmi/chains':
@@ -186,7 +186,7 @@ importers:
       '@latticexyz/world':
         specifier: 2.0.0-alpha.1.196
         version: 2.0.0-alpha.1.196(typescript@5.0.4)
-      '@succinctlabs/mudvrf-contracts':
+      '@succinctlabs/mudvrf':
         specifier: workspace:*
         version: link:../contracts
       ethers:


### PR DESCRIPTION
this isn't important, just a suggestion for some confusing remappings that tripped me up during https://github.com/jtguibas/mudvrf/pull/13

more suggestions:
- you don't need `src/modules/vrf`, since all of your solidity code is a module. It can just be in `src`
- modules tend to have pretty bad UX, you should eventually wrap it in a plugin (we have yet to do that for MUD-native modules though, so no good examples yet), you can separate the plugin stuff in a `ts` folder https://github.com/latticexyz/mud/tree/main/examples/minimal/packages/plugin-example
- I guess many files are copied from chainlink, so instead you could add it as a dep and import them to simplify ur package. I think the only downside would be another remapping for users